### PR TITLE
Removes need for default constructor

### DIFF
--- a/Bank.cs
+++ b/Bank.cs
@@ -147,7 +147,7 @@ namespace SuncoastBank
         {
             if (amount < 0) return AccountError.UNDERFLOW;
 
-            CommitTransaction(new Transaction(AccountID, depositAccount, AccountAction.DEPOSIT, amount));
+            CommitTransaction(new Transaction(AccountID, depositAccount, amount, AccountAction.DEPOSIT));
 
             return AccountError.NONE;
         }
@@ -158,7 +158,7 @@ namespace SuncoastBank
             if (amount < 0) return AccountError.UNDERFLOW;
             if (amount > SumTransactionsFor(withdrawAccount)) return AccountError.OVERFLOW;
 
-            CommitTransaction(new Transaction(AccountID, withdrawAccount, AccountAction.WITHDRAWAL, amount));
+            CommitTransaction(new Transaction(AccountID, withdrawAccount, amount, AccountAction.WITHDRAWAL));
 
             return AccountError.NONE;
         }
@@ -170,7 +170,7 @@ namespace SuncoastBank
             int result = WithdrawFrom(withdrawAccount, amount);
             if (result == AccountError.NONE)
             {
-                CommitTransaction(new Transaction(AccountID, transferAccount, AccountAction.DEPOSIT, amount));
+                CommitTransaction(new Transaction(AccountID, transferAccount, amount, AccountAction.DEPOSIT));
             }
 
             return result;

--- a/Transaction.cs
+++ b/Transaction.cs
@@ -2,18 +2,17 @@ namespace SuncoastBank
 {
     public class Transaction
     {
-        public int AccountID { get; set; }
-        public int AccountType { get; set; }
-        public int AccountDelta { get; set; }
-        public int AccountAction { get; set; }
+        public int AccountID { get; }
+        public int AccountType { get; }
+        public int AccountDelta { get; }
+        public int AccountAction { get; }
 
-        public Transaction() { }
-        public Transaction(int accountID, int accountType, int accountAction, int accountDelta)
+        public Transaction(int AccountID, int AccountType, int AccountDelta, int AccountAction)
         {
-            AccountID = accountID;
-            AccountType = accountType;
-            AccountAction = accountAction;
-            AccountDelta = accountDelta;
+            this.AccountID = AccountID;
+            this.AccountType = AccountType;
+            this.AccountAction = AccountAction;
+            this.AccountDelta = AccountDelta;
         }
     }
 }


### PR DESCRIPTION
By making the argument names to our constructor the same as the CSV field names, it appears CsvHelper can find the constructor to use without having to use the property `set` methods.

Thus we can remove them. Since the argument names and the property names are the same we prefix the assignment with `this.` to avoid ambiguity.

We can remove the `set` from the properties.

To prove that it works by finding the appropriate constructor based on the argument names I swapped around the argument order.

I haven't dug into `CsvReader` to see how this works as I'm not sure this is a C# feature or something that CsvReader does specifically.